### PR TITLE
Return implicitly protected ATermInt from the binary stream reader to avoid unnecessary protections

### DIFF
--- a/crates/aterm/src/aterm.rs
+++ b/crates/aterm/src/aterm.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::marker::PhantomData;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -23,6 +22,7 @@ use crate::ATermList;
 use crate::Markable;
 use crate::Symb;
 use crate::SymbolRef;
+use crate::Transmutable;
 use crate::is_empty_list_term;
 use crate::is_int_term;
 use crate::is_list_term;
@@ -495,18 +495,7 @@ impl<T> Return<T> {
     }
 }
 
-impl<'a, 'b, T> Deref for Return<T>
-where
-    T: Term<'a, 'b>,
-{
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.term
-    }
-}
-
-impl<'a, 'b, T: Term<'a, 'b>> Term<'a, 'b> for &'b Return<T>
+impl<'a, 'b, T: Term<'a, 'b>> Term<'a, 'b> for Return<T>
 where
     'b: 'a,
 {

--- a/crates/aterm/src/aterm.rs
+++ b/crates/aterm/src/aterm.rs
@@ -495,6 +495,13 @@ impl<T> Return<T> {
     }
 }
 
+impl<T: Transmutable> Return<T> {
+    /// Maps the inner term to another type, while keeping the same guard.
+    pub fn inner(&self) -> &T::Target<'_> {
+        &self.term.transmute_lifetime()
+    }
+}
+
 impl<'a, 'b, T: Term<'a, 'b>> Term<'a, 'b> for Return<T>
 where
     'b: 'a,
@@ -502,11 +509,11 @@ where
     delegate! {
         to self.term {
             fn protect(&self) -> ATerm;
-            fn arg(&self, index: usize) -> ATermRef<'a>;
-            fn arguments(&self) -> ATermArgs<'a>;
-            fn copy(&self) -> ATermRef<'a>;
-            fn get_head_symbol(&self) -> SymbolRef<'a>;
-            fn iter(&self) -> TermIterator<'a>;
+            fn arg(&'b self, index: usize) -> ATermRef<'a>;
+            fn arguments(&'b self) -> ATermArgs<'a>;
+            fn copy(&'b self) -> ATermRef<'a>;
+            fn get_head_symbol(&'b self) -> SymbolRef<'a>;
+            fn iter(&'b self) -> TermIterator<'a>;
             fn index(&self) -> usize;
             fn shared(&self) -> &ATermIndex;
         }

--- a/crates/aterm/src/aterm.rs
+++ b/crates/aterm/src/aterm.rs
@@ -243,7 +243,7 @@ impl ATerm {
     }
 
     /// Creates a new term with the given symbol and an iterator over the arguments.
-    pub fn try_with_iter<'a, 'b, 'c, 'd, S, I, T>(symbol: &'b S, iter: I) -> Result<ATerm, MercError>
+    pub fn try_with_iter<'a, 'b, 'c, 'd, S, I, T>(symbol: &'b S, iter: I) -> Result<Return<ATermRef<'static>>, MercError>
     where
         S: Symb<'a, 'b>,
         I: IntoIterator<Item = Result<T, MercError>>,
@@ -480,9 +480,15 @@ impl<T> Return<T> {
         Return { term, guard }
     }
 
-    /// Consumes the return value and returns the inner term.
-    pub fn into(self) -> T {
-        self.term
+    /// Casts the inner term to another type, while keeping the same guard.
+    pub fn cast<U>(self) -> Return<U>
+    where
+        T: Into<U>,
+    {
+        Return {
+            term: self.term.into(),
+            guard: self.guard,
+        }
     }
 }
 

--- a/crates/aterm/src/aterm.rs
+++ b/crates/aterm/src/aterm.rs
@@ -243,7 +243,10 @@ impl ATerm {
     }
 
     /// Creates a new term with the given symbol and an iterator over the arguments.
-    pub fn try_with_iter<'a, 'b, 'c, 'd, S, I, T>(symbol: &'b S, iter: I) -> Result<Return<ATermRef<'static>>, MercError>
+    pub fn try_with_iter<'a, 'b, 'c, 'd, S, I, T>(
+        symbol: &'b S,
+        iter: I,
+    ) -> Result<Return<ATermRef<'static>>, MercError>
     where
         S: Symb<'a, 'b>,
         I: IntoIterator<Item = Result<T, MercError>>,

--- a/crates/aterm/src/aterm_binary_stream.rs
+++ b/crates/aterm/src/aterm_binary_stream.rs
@@ -20,6 +20,7 @@ use crate::ATermInt;
 use crate::ATermIntRef;
 use crate::ATermRef;
 use crate::Protected;
+use crate::Return;
 use crate::Symb;
 use crate::Symbol;
 use crate::SymbolRef;
@@ -93,7 +94,7 @@ pub trait ATermWrite {
 /// Trait for reading ATerms from a stream.
 pub trait ATermRead {
     /// Reads the next ATerm from the stream. Returns None when the end of the stream is reached.
-    fn read_aterm(&mut self) -> Result<Option<ATerm>, MercError>;
+    fn read_aterm(&mut self) -> Result<Option<Return<ATermRef<'static>>>, MercError>;
 
     /// Reads an iterator of ATerms from the stream.
     fn read_aterm_iter(&mut self) -> Result<impl ExactSizeIterator<Item = Result<ATerm, MercError>>, MercError>;
@@ -277,7 +278,7 @@ impl<W: Write> ATermWrite for BinaryATermWriter<W> {
     where
         I: ExactSizeIterator<Item = ATerm>,
     {
-        self.write_aterm(&ATermInt::new(iter.len()))?;
+        self.write_aterm(&ATermInt::new(iter.len()).protect())?;
         for ldd in iter {
             self.write_aterm(&ldd)?;
         }
@@ -397,7 +398,7 @@ impl<R: Read> BinaryATermReader<R> {
 }
 
 impl<R: Read> ATermRead for BinaryATermReader<R> {
-    fn read_aterm(&mut self) -> Result<Option<ATerm>, MercError> {
+    fn read_aterm(&mut self) -> Result<Option<Return<ATermRef<'static>>>, MercError> {
         if self.ended {
             return Err(Error::new(
                 ErrorKind::UnexpectedEof,
@@ -426,7 +427,7 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
                 PacketType::ATermIntOutput => {
                     let value = self.stream.read_integer()?.try_into()?;
                     debug_trace!("Output int term: {}", ATermInt::new(value));
-                    return Ok(Some(ATermInt::new(value).into()));
+                    return Ok(Some(ATermInt::new(value).cast()));
                 }
                 PacketType::ATerm | PacketType::ATermOutput => {
                     let symbol_index = self.stream.read_bits(self.function_symbol_index_width())? as usize;
@@ -449,7 +450,7 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
                         debug_trace!("Read int term: {term}");
 
                         let mut write_terms = self.terms.write();
-                        let t = write_terms.protect(&term);
+                        let t = write_terms.protect(&*term);
                         write_terms.push(t);
                         self.term_index_width = bits_for_value(write_terms.len());
                     } else {
@@ -477,7 +478,7 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
                         }
                         debug_trace!("Read term: {term}");
 
-                        let t = write_terms.protect(&term);
+                        let t = write_terms.protect(&*term);
                         write_terms.push(t);
                         self.term_index_width = bits_for_value(write_terms.len());
                     }
@@ -495,10 +496,10 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
             .into());
         }
 
-        let number_of_elements: ATermInt = self
+        let number_of_elements: Return<ATermIntRef<'static>> = self
             .read_aterm()?
             .ok_or("Missing number of elements for iterator")?
-            .into();
+            .cast();
         Ok(ATermReadIter {
             reader: self,
             remaining: number_of_elements.value(),
@@ -532,7 +533,7 @@ impl<'a, R: Read> Iterator for ATermReadIter<'a, R> {
 
         self.remaining -= 1;
         match self.reader.read_aterm() {
-            Ok(Some(term)) => Some(Ok(term)),
+            Ok(Some(term)) => Some(Ok(term.protect())),
             Ok(None) => Some(Err(Error::new(
                 ErrorKind::UnexpectedEof,
                 "Unexpected end of stream while reading iterator",
@@ -561,7 +562,8 @@ mod tests {
     use crate::ATermWrite;
     use crate::BinaryATermReader;
     use crate::BinaryATermWriter;
-    use crate::random_term;
+    use crate::Term;
+use crate::random_term;
 
     #[test]
     #[cfg_attr(miri, ignore)] // Miri is too slow
@@ -585,7 +587,7 @@ mod tests {
                 println!("Term {}", term);
                 debug_assert_eq!(
                     *term,
-                    input_stream.read_aterm().unwrap().unwrap(),
+                    input_stream.read_aterm().unwrap().unwrap().protect(),
                     "The read term must match the term that we have written"
                 );
             }

--- a/crates/aterm/src/aterm_binary_stream.rs
+++ b/crates/aterm/src/aterm_binary_stream.rs
@@ -450,7 +450,7 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
                         debug_trace!("Read int term: {term}");
 
                         let mut write_terms = self.terms.write();
-                        let t = write_terms.protect(&*term);
+                        let t = write_terms.protect(&term.inner());
                         write_terms.push(t);
                         self.term_index_width = bits_for_value(write_terms.len());
                     } else {
@@ -478,7 +478,7 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
                         }
                         debug_trace!("Read term: {term}");
 
-                        let t = write_terms.protect(&*term);
+                        let t = write_terms.protect(&term.inner());
                         write_terms.push(t);
                         self.term_index_width = bits_for_value(write_terms.len());
                     }
@@ -502,7 +502,7 @@ impl<R: Read> ATermRead for BinaryATermReader<R> {
             .cast();
         Ok(ATermReadIter {
             reader: self,
-            remaining: number_of_elements.value(),
+            remaining: number_of_elements.inner().value(),
         })
     }
 }

--- a/crates/aterm/src/aterm_binary_stream.rs
+++ b/crates/aterm/src/aterm_binary_stream.rs
@@ -129,11 +129,11 @@ pub struct BinaryATermWriter<W: Write> {
     stream: BitStreamWriter<W>,
 
     /// Stores the function symbols and the number of bits needed to encode their indices.
-    function_symbols: IndexedSet<Symbol>,
+    function_symbols: Protected<IndexedSet<SymbolRef<'static>>>,
     function_symbol_index_width: u8,
 
     /// Stores the terms and the number of bits needed to encode their indices.
-    terms: IndexedSet<ATerm>,
+    terms: Protected<IndexedSet<ATermRef<'static>>>,
     term_index_width: u8,
 
     /// Indicates whether the stream has been flushed.
@@ -153,15 +153,16 @@ impl<W: Write> BinaryATermWriter<W> {
         stream.write_bits(BAF_MAGIC as u64, 16)?;
         stream.write_bits(BAF_VERSION as u64, 16)?;
 
-        let mut function_symbols = IndexedSet::new();
+        let mut function_symbols = Protected::new(IndexedSet::new());
         // The term with function symbol index 0 indicates the end of the stream
-        function_symbols.insert(Symbol::new("end_of_stream".to_string(), 0));
+        let end_of_stream_symbol = Symbol::new(String::new(), 0);
+        function_symbols.write().insert(end_of_stream_symbol.copy());
 
         Ok(Self {
             stream,
             function_symbols,
             function_symbol_index_width: 1,
-            terms: IndexedSet::new(),
+            terms: Protected::new(IndexedSet::new()),
             term_index_width: 1,
             stack: VecDeque::new(),
             flushed: false,
@@ -170,14 +171,14 @@ impl<W: Write> BinaryATermWriter<W> {
 
     /// \brief Write a function symbol to the output stream.
     fn write_function_symbol(&mut self, symbol: &SymbolRef<'_>) -> Result<usize, MercError> {
-        let (index, inserted) = self.function_symbols.insert(symbol.protect());
+        let (index, inserted) = self.function_symbols.write().insert(symbol.copy());
 
         if inserted {
             // Write the function symbol to the stream
             self.stream.write_bits(PacketType::FunctionSymbol as u64, PACKET_BITS)?;
             self.stream.write_string(symbol.name())?;
             self.stream.write_integer(symbol.arity() as u64)?;
-            self.function_symbol_index_width = bits_for_value(self.function_symbols.len());
+            self.function_symbol_index_width = bits_for_value(self.function_symbols.read().len());
         }
 
         Ok(*index)
@@ -185,7 +186,7 @@ impl<W: Write> BinaryATermWriter<W> {
 
     /// Returns the current bit width needed to encode a function symbol index.
     fn function_symbol_index_width(&self) -> u8 {
-        let expected = bits_for_value(self.function_symbols.len());
+        let expected = bits_for_value(self.function_symbols.read().len());
         debug_assert_eq!(
             self.function_symbol_index_width, expected,
             "function_symbol_index_width does not match bits_for_value",
@@ -196,7 +197,7 @@ impl<W: Write> BinaryATermWriter<W> {
 
     /// Returns the current bit width needed to encode a term index.
     fn term_index_width(&self) -> u8 {
-        let expected = bits_for_value(self.terms.len());
+        let expected = bits_for_value(self.terms.read().len());
         debug_assert_eq!(
             self.term_index_width, expected,
             "term_index_width does not match bits_for_value",
@@ -213,7 +214,7 @@ impl<W: Write> ATermWrite for BinaryATermWriter<W> {
             // Indicates that this term is output and not a subterm, these should always be written.
             let is_output = self.stack.is_empty();
 
-            if !self.terms.contains(&current_term) || is_output {
+            if !self.terms.read().contains(&current_term.copy()) || is_output {
                 if write_ready {
                     if is_int_term(&current_term) {
                         let int_term = ATermIntRef::from(current_term.copy());
@@ -242,15 +243,15 @@ impl<W: Write> ATermWrite for BinaryATermWriter<W> {
                             .write_bits(symbol_index as u64, self.function_symbol_index_width())?;
 
                         for arg in current_term.arguments() {
-                            let index = self.terms.index(&arg).expect("Argument must already be written");
+                            let index = self.terms.read().index(&arg).expect("Argument must already be written");
                             self.stream.write_bits(*index as u64, self.term_index_width())?;
                         }
                     }
 
                     if !is_output {
-                        let (_, inserted) = self.terms.insert(current_term);
+                        let (_, inserted) = self.terms.write().insert(current_term.copy());
                         assert!(inserted, "This term should have a new index assigned.");
-                        self.term_index_width = bits_for_value(self.terms.len());
+                        self.term_index_width = bits_for_value(self.terms.read().len());
                     }
                 } else {
                     // Add current term back to stack for writing after processing arguments
@@ -258,7 +259,7 @@ impl<W: Write> ATermWrite for BinaryATermWriter<W> {
 
                     // Add arguments to stack for processing first
                     for arg in current_term.arguments() {
-                        if !self.terms.contains(&arg) {
+                        if !self.terms.read().contains(&arg) {
                             self.stack.push_back((arg.protect(), false));
                         }
                     }

--- a/crates/aterm/src/aterm_binary_stream.rs
+++ b/crates/aterm/src/aterm_binary_stream.rs
@@ -563,7 +563,7 @@ mod tests {
     use crate::BinaryATermReader;
     use crate::BinaryATermWriter;
     use crate::Term;
-use crate::random_term;
+    use crate::random_term;
 
     #[test]
     #[cfg_attr(miri, ignore)] // Miri is too slow

--- a/crates/aterm/src/aterm_int.rs
+++ b/crates/aterm/src/aterm_int.rs
@@ -28,6 +28,7 @@ mod inner {
     use crate::ATermIndex;
     use crate::ATermRef;
     use crate::Markable;
+    use crate::Return;
     use crate::SymbolRef;
     use crate::Term;
     use crate::TermIterator;
@@ -45,10 +46,8 @@ mod inner {
 
     impl ATermInt {
         #[merc_ignore]
-        pub fn new(value: usize) -> ATermInt {
-            THREAD_TERM_POOL.with_borrow(|tp| ATermInt {
-                term: tp.create_int(value),
-            })
+        pub fn new(value: usize) -> Return<ATermIntRef<'static>> {
+            THREAD_TERM_POOL.with_borrow(|tp| tp.create_int(value).cast())
         }
 
         /// Returns the value of the integer term.
@@ -91,6 +90,6 @@ mod tests {
 
         let int_term = ATermInt::new(42);
         assert_eq!(int_term.value(), 42);
-        assert!(is_int_term(&int_term));
+        assert!(is_int_term(&*int_term));
     }
 }

--- a/crates/aterm/src/aterm_int.rs
+++ b/crates/aterm/src/aterm_int.rs
@@ -89,7 +89,7 @@ mod tests {
         let _ = test_logger();
 
         let int_term = ATermInt::new(42);
-        assert_eq!(int_term.value(), 42);
-        assert!(is_int_term(&*int_term));
+        assert_eq!(int_term.inner().value(), 42);
+        assert!(is_int_term(&int_term.inner()));
     }
 }

--- a/crates/aterm/src/aterm_list.rs
+++ b/crates/aterm/src/aterm_list.rs
@@ -228,7 +228,14 @@ mod tests {
 
     #[test]
     fn test_list_term() {
-        let list = ATermList::from_double_iter(vec![ATermInt::new(1).protect(), ATermInt::new(2).protect(), ATermInt::new(3).protect()].into_iter());
+        let list = ATermList::from_double_iter(
+            vec![
+                ATermInt::new(1).protect(),
+                ATermInt::new(2).protect(),
+                ATermInt::new(3).protect(),
+            ]
+            .into_iter(),
+        );
         assert_eq!(list.head().value(), 1);
         assert_eq!(list.tail().head().value(), 2);
         assert_eq!(list.tail().tail().head().value(), 3);

--- a/crates/aterm/src/aterm_list.rs
+++ b/crates/aterm/src/aterm_list.rs
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_list_term() {
-        let list = ATermList::from_double_iter(vec![ATermInt::new(1), ATermInt::new(2), ATermInt::new(3)].into_iter());
+        let list = ATermList::from_double_iter(vec![ATermInt::new(1).protect(), ATermInt::new(2).protect(), ATermInt::new(3).protect()].into_iter());
         assert_eq!(list.head().value(), 1);
         assert_eq!(list.tail().head().value(), 2);
         assert_eq!(list.tail().tail().head().value(), 3);

--- a/crates/aterm/src/aterm_list.rs
+++ b/crates/aterm/src/aterm_list.rs
@@ -230,9 +230,9 @@ mod tests {
     fn test_list_term() {
         let list = ATermList::from_double_iter(
             vec![
-                ATermInt::new(1).protect(),
-                ATermInt::new(2).protect(),
-                ATermInt::new(3).protect(),
+                ATermInt::new(1).inner().protect(),
+                ATermInt::new(2).inner().protect(),
+                ATermInt::new(3).inner().protect(),
             ]
             .into_iter(),
         );

--- a/crates/aterm/src/aterm_string.rs
+++ b/crates/aterm/src/aterm_string.rs
@@ -6,6 +6,7 @@ use merc_utilities::MercError;
 use crate::ATermRead;
 use crate::ATermStreamable;
 use crate::ATermWrite;
+use crate::Return;
 use crate::Symb;
 use crate::Term;
 
@@ -98,7 +99,7 @@ impl ATermStreamable for String {
     where
         Self: Sized,
     {
-        let term: ATermString = reader.read_aterm()?.ok_or("Expected a string ATerm")?.into();
+        let term: Return<ATermStringRef<'static>> = reader.read_aterm()?.ok_or("Expected a string ATerm")?.cast();
         Ok(term.value().to_string())
     }
 }

--- a/crates/aterm/src/aterm_string.rs
+++ b/crates/aterm/src/aterm_string.rs
@@ -100,7 +100,7 @@ impl ATermStreamable for String {
         Self: Sized,
     {
         let term: Return<ATermStringRef<'static>> = reader.read_aterm()?.ok_or("Expected a string ATerm")?.cast();
-        Ok(term.value().to_string())
+        Ok(term.inner().value().to_string())
     }
 }
 

--- a/crates/aterm/src/storage/thread_aterm_pool.rs
+++ b/crates/aterm/src/storage/thread_aterm_pool.rs
@@ -141,7 +141,7 @@ impl ThreadTermPool {
     pub fn create_int(&self, value: usize) -> Return<ATermRef<'static>> {
         let guard = self.term_pool.read_recursive().expect("Lock poisoned!");
         let (index, inserted) = guard.create_int(value);
-        let result =  self.make_return(guard, index);
+        let result = self.make_return(guard, index);
 
         if inserted {
             // Intentially called after the guard is dropped.
@@ -180,7 +180,11 @@ impl ThreadTermPool {
     }
 
     /// Create a term with the given arguments given by the iterator that is failable.
-    pub fn try_create_term_iter<'a, 'b, 'c, 'd, S, I, T>(&self, symbol: &'b S, args: I) -> Result<Return<ATermRef<'static>>, MercError>
+    pub fn try_create_term_iter<'a, 'b, 'c, 'd, S, I, T>(
+        &self,
+        symbol: &'b S,
+        args: I,
+    ) -> Result<Return<ATermRef<'static>>, MercError>
     where
         S: Symb<'a, 'b>,
         I: IntoIterator<Item = Result<T, MercError>>,
@@ -297,7 +301,11 @@ impl ThreadTermPool {
     }
 
     /// Protects a term and returns a Return that will automatically unprotect the term when dropped.
-    pub fn make_return(&self, guard: RecursiveLockReadGuard<'_, GlobalTermPool>, index: ATermIndex) -> Return<ATermRef<'static>> {
+    pub fn make_return(
+        &self,
+        guard: RecursiveLockReadGuard<'_, GlobalTermPool>,
+        index: ATermIndex,
+    ) -> Return<ATermRef<'static>> {
         unsafe {
             // SAFETY: The guard is guaranteed to live as long as the returned term, since it is thread local and Return cannot be sent to other threads.
             Return::new(

--- a/crates/aterm/src/storage/thread_aterm_pool.rs
+++ b/crates/aterm/src/storage/thread_aterm_pool.rs
@@ -127,13 +127,7 @@ impl ThreadTermPool {
 
         let (index, inserted) = guard.create_term_array(symbol, &arguments);
 
-        let result = unsafe {
-            // SAFETY: The guard is guaranteed to live as long as the returned term, since it is thread local and Return cannot be sended to other threads.
-            Return::new(
-                std::mem::transmute::<RecursiveLockReadGuard<'_, _>, RecursiveLockReadGuard<'static, _>>(guard),
-                ATermRef::from_index(&index),
-            )
-        };
+        let result = self.make_return(guard, index);
 
         if inserted {
             // Intentially called after the guard is dropped.
@@ -144,10 +138,10 @@ impl ThreadTermPool {
     }
 
     /// Create a term with the given index.
-    pub fn create_int(&self, value: usize) -> ATerm {
+    pub fn create_int(&self, value: usize) -> Return<ATermRef<'static>> {
         let guard = self.term_pool.read_recursive().expect("Lock poisoned!");
         let (index, inserted) = guard.create_int(value);
-        let result = self.protect_guard(guard, &unsafe { ATermRef::from_index(&index) });
+        let result =  self.make_return(guard, index);
 
         if inserted {
             // Intentially called after the guard is dropped.
@@ -185,8 +179,8 @@ impl ThreadTermPool {
         result
     }
 
-    /// Create a term with the given arguments given by the iterator that is fallible.
-    pub fn try_create_term_iter<'a, 'b, 'c, 'd, S, I, T>(&self, symbol: &'b S, args: I) -> Result<ATerm, MercError>
+    /// Create a term with the given arguments given by the iterator that is failable.
+    pub fn try_create_term_iter<'a, 'b, 'c, 'd, S, I, T>(&self, symbol: &'b S, args: I) -> Result<Return<ATermRef<'static>>, MercError>
     where
         S: Symb<'a, 'b>,
         I: IntoIterator<Item = Result<T, MercError>>,
@@ -203,7 +197,7 @@ impl ThreadTermPool {
 
         let (index, inserted) = guard.create_term_array(symbol, &arguments);
 
-        let result = Ok(self.protect_guard(guard, &unsafe { ATermRef::from_index(&index) }));
+        let result = Ok(self.make_return(guard, index));
 
         if inserted {
             // Intentially called after the guard is dropped.
@@ -300,6 +294,17 @@ impl ThreadTermPool {
         );
 
         result
+    }
+
+    /// Protects a term and returns a Return that will automatically unprotect the term when dropped.
+    pub fn make_return(&self, guard: RecursiveLockReadGuard<'_, GlobalTermPool>, index: ATermIndex) -> Return<ATermRef<'static>> {
+        unsafe {
+            // SAFETY: The guard is guaranteed to live as long as the returned term, since it is thread local and Return cannot be sent to other threads.
+            Return::new(
+                std::mem::transmute::<RecursiveLockReadGuard<'_, _>, RecursiveLockReadGuard<'static, _>>(guard),
+                ATermRef::from_index(&index),
+            )
+        }
     }
 
     /// Unprotects a term from this thread's protection set.

--- a/crates/aterm/tests/build_tests.rs
+++ b/crates/aterm/tests/build_tests.rs
@@ -3,5 +3,6 @@
 fn test_soundness() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/input/aterm_lifetime.rs");
+    t.compile_fail("tests/input/aterm_return_lifetime.rs");
     t.compile_fail("tests/input/aterm_container_lifetime.rs");
 }

--- a/crates/aterm/tests/input/aterm_return_lifetime.rs
+++ b/crates/aterm/tests/input/aterm_return_lifetime.rs
@@ -1,10 +1,9 @@
 use merc_aterm::ATermInt;
-use merc_aterm::Term;
 
 fn main() {
     let term = {
         let i = ATermInt::new(42);
-        (*i).copy();
+        i.inner()
     };
 
     // Have some side effect    

--- a/crates/aterm/tests/input/aterm_return_lifetime.rs
+++ b/crates/aterm/tests/input/aterm_return_lifetime.rs
@@ -1,0 +1,12 @@
+use merc_aterm::ATermInt;
+use merc_aterm::Term;
+
+fn main() {
+    let term = {
+        let i = ATermInt::new(42);
+        (*i).copy();
+    };
+
+    // Have some side effect    
+    println!("Term: {:?}", term);
+}

--- a/crates/aterm/tests/input/aterm_return_lifetime.stderr
+++ b/crates/aterm/tests/input/aterm_return_lifetime.stderr
@@ -1,0 +1,11 @@
+error[E0597]: `i` does not live long enough
+ --> tests/input/aterm_return_lifetime.rs:6:9
+  |
+4 |     let term = {
+  |         ---- borrow later stored here
+5 |         let i = ATermInt::new(42);
+  |             - binding `i` declared here
+6 |         i.inner()
+  |         ^ borrowed value does not live long enough
+7 |     };
+  |     - `i` dropped here while still borrowed

--- a/crates/ldd/src/io_ldd.rs
+++ b/crates/ldd/src/io_ldd.rs
@@ -11,6 +11,8 @@ use std::cell::RefCell;
 
 use merc_aterm::ATerm;
 use merc_aterm::ATermRead;
+use merc_aterm::ATermRef;
+use merc_aterm::Return;
 use merc_collections::IndexedSet;
 use merc_io::BitStreamRead;
 use merc_io::BitStreamWrite;
@@ -159,7 +161,7 @@ impl<R: BitStreamRead> BinaryLddReader<R> {
 impl<R: BitStreamRead + ATermRead> ATermRead for BinaryLddReader<R> {
     delegate::delegate! {
         to self.reader {
-            fn read_aterm(&mut self) -> Result<Option<ATerm>, MercError>;
+            fn read_aterm(&mut self) -> Result<Option<Return<ATermRef<'static>>>, MercError>;
             fn read_aterm_iter(&mut self) -> Result<impl ExactSizeIterator<Item = Result<ATerm, MercError>>, MercError>;
         }
     }

--- a/crates/lts/src/io_lts.rs
+++ b/crates/lts/src/io_lts.rs
@@ -41,7 +41,7 @@ pub fn read_lts<R: Read>(
 
     let mut reader = BinaryATermReader::new(BufReader::new(reader))?;
 
-    if reader.read_aterm()? != Some(lts_marker()) {
+    if reader.read_aterm()?.map(|t| t.copy()) != Some(lts_marker().copy()) {
         return Err("Stream does not contain a labelled transition system (LTS).".into());
     }
 
@@ -108,17 +108,17 @@ pub fn read_lts<R: Read>(
                         state_labels.push(t);
                     }
                 } else if *t == initial_state_marker.copy() {
-                    let length = ATermInt::from(reader.read_aterm()?.ok_or("Missing initial state length")?).value();
+                    let length = reader.read_aterm()?.ok_or("Missing initial state length")?.cast::<ATermIntRef<'static>>().value();
                     if length != 1 {
                         return Err("Initial state length greater than 1 is not supported.".into());
                     }
 
                     initial_state = Some(StateIndex::new(
-                        *(reader.read_aterm()?.ok_or("Missing initial state index")?.into()).value(),
+                        (reader.read_aterm()?.ok_or("Missing initial state index")?.cast::<ATermIntRef<'static>>()).value(),
                     ));
                     debug!("Initial state: {:?}", initial_state);
                 } else {
-                    return Err(format!("Unexpected term in LTS stream: {}", t).into());
+                    return Err(format!("Unexpected term in LTS stream: {}", *t).into());
                 }
             }
             None => break, // The default constructed term indicates the end of the stream.

--- a/crates/lts/src/io_lts.rs
+++ b/crates/lts/src/io_lts.rs
@@ -10,6 +10,7 @@ use log::debug;
 use log::info;
 use merc_aterm::ATerm;
 use merc_aterm::ATermInt;
+use merc_aterm::ATermIntRef;
 use merc_aterm::ATermList;
 use merc_aterm::ATermRead;
 use merc_aterm::ATermStreamable;
@@ -17,6 +18,7 @@ use merc_aterm::ATermWrite;
 use merc_aterm::BinaryATermReader;
 use merc_aterm::BinaryATermWriter;
 use merc_aterm::Symbol;
+use merc_aterm::Term;
 use merc_aterm::is_list_term;
 use merc_data::DataSpecification;
 use merc_io::LargeFormatter;
@@ -64,50 +66,55 @@ pub fn read_lts<R: Read>(
 
     let mut state_labels = Vec::new();
 
+    // Cache the markers to avoid constructing them repeatedly in the loop.
+    let transition_marker = transition_marker();
+    let probabilistic_transition_marker = probabilistic_transition_marker();
+    let initial_state_marker = initial_state_marker();
+
     loop {
         let term = reader.read_aterm()?;
         match term {
             Some(t) => {
-                if t == transition_marker() {
-                    let from: ATermInt = reader.read_aterm()?.ok_or("Missing from state")?.into();
+                if *t == transition_marker.copy() {
+                    let from: usize = reader.read_aterm()?.ok_or("Missing from state")?.cast::<ATermIntRef<'static>>().value();
                     let label = reader.read_aterm()?.ok_or("Missing transition label")?;
-                    let to: ATermInt = reader.read_aterm()?.ok_or("Missing to state")?.into();
+                    let to: usize = reader.read_aterm()?.ok_or("Missing to state")?.cast::<ATermIntRef<'static>>().value();
 
-                    if let Some(multi_action) = multi_actions.get(&label) {
+                    if let Some(multi_action) = multi_actions.get(&*label) {
                         // Multi-action already exists in the cache.
                         builder.add_transition(
-                            StateIndex::new(from.value()),
+                            StateIndex::new(from),
                             multi_action,
-                            StateIndex::new(to.value()),
+                            StateIndex::new(to),
                         )?;
                     } else {
                         // New multi-action found, add it to the builder.
-                        let multi_action = LtsMultiAction::from_mcrl2_aterm(label.clone())?;
-                        multi_actions.insert(label.clone(), multi_action.clone());
+                        let multi_action = LtsMultiAction::from_mcrl2_aterm(label.protect())?;
+                        multi_actions.insert(label.protect(), multi_action.clone());
                         builder.add_transition(
-                            StateIndex::new(from.value()),
+                            StateIndex::new(from),
                             &multi_action,
-                            StateIndex::new(to.value()),
+                            StateIndex::new(to),
                         )?;
                     }
 
                     progress.print(builder.num_of_transitions());
-                } else if t == probabilistic_transition_mark() {
+                } else if *t == probabilistic_transition_marker.copy() {
                     return Err("Probabilistic transitions are not supported yet.".into());
-                } else if is_list_term(&t) {
+                } else if is_list_term(&*t) {
                     if read_state_labels {
-                        let t: ATermList<ATerm> = t.into();
+                        let t: ATermList<ATerm> = t.protect().into();
                         debug!("Read state label: {:?}", t.to_vec());
                         state_labels.push(t);
                     }
-                } else if t == initial_state_marker() {
+                } else if *t == initial_state_marker.copy() {
                     let length = ATermInt::from(reader.read_aterm()?.ok_or("Missing initial state length")?).value();
                     if length != 1 {
                         return Err("Initial state length greater than 1 is not supported.".into());
                     }
 
                     initial_state = Some(StateIndex::new(
-                        ATermInt::from(reader.read_aterm()?.ok_or("Missing initial state index")?).value(),
+                        *(reader.read_aterm()?.ok_or("Missing initial state index")?.into()).value(),
                     ));
                     debug!("Initial state: {:?}", initial_state);
                 } else {
@@ -179,8 +186,8 @@ where
 
     // Write the initial state.
     writer.write_aterm(&initial_state_marker())?;
-    writer.write_aterm(&ATermInt::new(1))?; // Length of initial state is 1.
-    writer.write_aterm(&ATermInt::new(*lts.initial_state_index()))?;
+    writer.write_aterm(&ATermInt::new(1).protect())?; // Length of initial state is 1.
+    writer.write_aterm(&ATermInt::new(*lts.initial_state_index()).protect())?;
 
     let num_of_transitions = lts.num_of_transitions();
     let progress = TimeProgress::new(
@@ -198,9 +205,9 @@ where
     for state in lts.iter_states() {
         for transition in lts.outgoing_transitions(state) {
             writer.write_aterm(&transition_marker())?;
-            writer.write_aterm(&ATermInt::new(*state))?;
+            writer.write_aterm(&ATermInt::new(*state).protect())?;
             writer.write_aterm(&label_terms[transition.label.value()])?;
-            writer.write_aterm(&ATermInt::new(*transition.to))?;
+            writer.write_aterm(&ATermInt::new(*transition.to).protect())?;
 
             progress.print(written);
             written += 1;
@@ -227,7 +234,7 @@ fn initial_state_marker() -> ATerm {
 }
 
 /// Returns the ATerm marker for the probabilistic transition.
-fn probabilistic_transition_mark() -> ATerm {
+fn probabilistic_transition_marker() -> ATerm {
     ATerm::constant(&Symbol::new("probabilistic_transition", 0))
 }
 

--- a/crates/lts/src/io_lts.rs
+++ b/crates/lts/src/io_lts.rs
@@ -41,7 +41,7 @@ pub fn read_lts<R: Read>(
 
     let mut reader = BinaryATermReader::new(BufReader::new(reader))?;
 
-    if reader.read_aterm()?.map(|t| t.copy()) != Some(lts_marker().copy()) {
+    if reader.read_aterm()?.map(|t| t.protect()) != Some(lts_marker()) {
         return Err("Stream does not contain a labelled transition system (LTS).".into());
     }
 
@@ -75,20 +75,22 @@ pub fn read_lts<R: Read>(
         let term = reader.read_aterm()?;
         match term {
             Some(t) => {
-                if *t == transition_marker.copy() {
+                if *t.inner() == transition_marker.copy() {
                     let from: usize = reader
                         .read_aterm()?
                         .ok_or("Missing from state")?
                         .cast::<ATermIntRef<'static>>()
+                        .inner()
                         .value();
                     let label = reader.read_aterm()?.ok_or("Missing transition label")?;
                     let to: usize = reader
                         .read_aterm()?
                         .ok_or("Missing to state")?
                         .cast::<ATermIntRef<'static>>()
+                        .inner()
                         .value();
 
-                    if let Some(multi_action) = multi_actions.get(&*label) {
+                    if let Some(multi_action) = multi_actions.get(&*label.inner()) {
                         // Multi-action already exists in the cache.
                         builder.add_transition(StateIndex::new(from), multi_action, StateIndex::new(to))?;
                     } else {
@@ -99,26 +101,36 @@ pub fn read_lts<R: Read>(
                     }
 
                     progress.print(builder.num_of_transitions());
-                } else if *t == probabilistic_transition_marker.copy() {
+                } else if *t.inner() == probabilistic_transition_marker.copy() {
                     return Err("Probabilistic transitions are not supported yet.".into());
-                } else if is_list_term(&*t) {
+                } else if is_list_term(&t.inner()) {
                     if read_state_labels {
                         let t: ATermList<ATerm> = t.protect().into();
                         debug!("Read state label: {:?}", t.to_vec());
                         state_labels.push(t);
                     }
-                } else if *t == initial_state_marker.copy() {
-                    let length = reader.read_aterm()?.ok_or("Missing initial state length")?.cast::<ATermIntRef<'static>>().value();
+                } else if *t.inner() == initial_state_marker.copy() {
+                    let length = reader
+                        .read_aterm()?
+                        .ok_or("Missing initial state length")?
+                        .cast::<ATermIntRef<'static>>()
+                        .inner()
+                        .value();
                     if length != 1 {
                         return Err("Initial state length greater than 1 is not supported.".into());
                     }
 
                     initial_state = Some(StateIndex::new(
-                        (reader.read_aterm()?.ok_or("Missing initial state index")?.cast::<ATermIntRef<'static>>()).value(),
+                        (reader
+                            .read_aterm()?
+                            .ok_or("Missing initial state index")?
+                            .cast::<ATermIntRef<'static>>())
+                        .inner()
+                        .value(),
                     ));
                     debug!("Initial state: {:?}", initial_state);
                 } else {
-                    return Err(format!("Unexpected term in LTS stream: {}", *t).into());
+                    return Err(format!("Unexpected term in LTS stream: {}", t.inner()).into());
                 }
             }
             None => break, // The default constructed term indicates the end of the stream.

--- a/crates/lts/src/io_lts.rs
+++ b/crates/lts/src/io_lts.rs
@@ -76,26 +76,26 @@ pub fn read_lts<R: Read>(
         match term {
             Some(t) => {
                 if *t == transition_marker.copy() {
-                    let from: usize = reader.read_aterm()?.ok_or("Missing from state")?.cast::<ATermIntRef<'static>>().value();
+                    let from: usize = reader
+                        .read_aterm()?
+                        .ok_or("Missing from state")?
+                        .cast::<ATermIntRef<'static>>()
+                        .value();
                     let label = reader.read_aterm()?.ok_or("Missing transition label")?;
-                    let to: usize = reader.read_aterm()?.ok_or("Missing to state")?.cast::<ATermIntRef<'static>>().value();
+                    let to: usize = reader
+                        .read_aterm()?
+                        .ok_or("Missing to state")?
+                        .cast::<ATermIntRef<'static>>()
+                        .value();
 
                     if let Some(multi_action) = multi_actions.get(&*label) {
                         // Multi-action already exists in the cache.
-                        builder.add_transition(
-                            StateIndex::new(from),
-                            multi_action,
-                            StateIndex::new(to),
-                        )?;
+                        builder.add_transition(StateIndex::new(from), multi_action, StateIndex::new(to))?;
                     } else {
                         // New multi-action found, add it to the builder.
                         let multi_action = LtsMultiAction::from_mcrl2_aterm(label.protect())?;
                         multi_actions.insert(label.protect(), multi_action.clone());
-                        builder.add_transition(
-                            StateIndex::new(from),
-                            &multi_action,
-                            StateIndex::new(to),
-                        )?;
+                        builder.add_transition(StateIndex::new(from), &multi_action, StateIndex::new(to))?;
                     }
 
                     progress.print(builder.num_of_transitions());

--- a/crates/symbolic/src/io_symbolic_lts.rs
+++ b/crates/symbolic/src/io_symbolic_lts.rs
@@ -9,6 +9,7 @@ use merc_aterm::ATermRead;
 use merc_aterm::ATermStreamable;
 use merc_aterm::BinaryATermReader;
 use merc_aterm::Symbol;
+use merc_aterm::Term;
 use merc_data::DataExpression;
 use merc_data::DataSpecification;
 use merc_data::DataVariable;
@@ -60,12 +61,12 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
     let aterm_stream = BinaryATermReader::new(BufReader::new(reader))?;
     let mut stream = BinaryLddReader::new(storage, aterm_stream)?;
 
-    if ATermRead::read_aterm(&mut stream)? != Some(symbolic_labelled_transition_system_mark()) {
+    if ATermRead::read_aterm(&mut stream)?.map(|t| t.copy()) != Some(symbolic_labelled_transition_system_mark().copy()) {
         return Err("Expected symbolic labelled transition system stream".into());
     }
 
     let data_spec = DataSpecification::read(&mut stream)?;
-    let process_parameters: ATermList<DataVariable> = stream.read_aterm()?.ok_or("Expected process parameters")?.into();
+    let process_parameters: ATermList<DataVariable> = stream.read_aterm()?.ok_or("Expected process parameters")?.protect().into();
     let process_parameters: Vec<DataVariable> = process_parameters.to_vec();
 
     let initial_state = stream.read_ldd(storage)?;
@@ -86,7 +87,7 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
         for i in 0..num_of_entries {
             let value = stream.read_aterm()?.ok_or("Unexpected end of stream")?;
 
-            let expr: DataExpression = value.into();
+            let expr: DataExpression = value.protect().into();
             debug!("  {i}:  {}", expr);
             values.push(expr);
         }
@@ -99,7 +100,7 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
     let mut action_labels = Vec::with_capacity(num_of_action_labels as usize);
     for _ in 0..num_of_action_labels {
         let action_label = stream.read_aterm()?.ok_or("Unexpected end of stream")?;
-        let action = LtsMultiAction::from_mcrl2_aterm(action_label)?;
+        let action = LtsMultiAction::from_mcrl2_aterm(action_label.protect())?;
 
         debug!("Action {}: {}", action_labels.len(), action);
         action_labels.push(action);
@@ -113,13 +114,13 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
         let num_of_reads = stream.read_integer()?;
         let mut read_parameters: Vec<DataVariable> = Vec::with_capacity(num_of_reads as usize);
         for _ in 0..num_of_reads {
-            read_parameters.push(stream.read_aterm()?.ok_or("Unexpected end of stream")?.into());
+            read_parameters.push(stream.read_aterm()?.ok_or("Unexpected end of stream")?.protect().into());
         }
 
         let num_of_writes = stream.read_integer()?;
         let mut write_parameters: Vec<DataVariable> = Vec::with_capacity(num_of_writes as usize);
         for _ in 0..num_of_writes {
-            write_parameters.push(stream.read_aterm()?.ok_or("Unexpected end of stream")?.into());
+            write_parameters.push(stream.read_aterm()?.ok_or("Unexpected end of stream")?.protect().into());
         }
 
         let relation = stream.read_ldd(storage)?;

--- a/crates/symbolic/src/io_symbolic_lts.rs
+++ b/crates/symbolic/src/io_symbolic_lts.rs
@@ -61,12 +61,17 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
     let aterm_stream = BinaryATermReader::new(BufReader::new(reader))?;
     let mut stream = BinaryLddReader::new(storage, aterm_stream)?;
 
-    if ATermRead::read_aterm(&mut stream)?.map(|t| t.copy()) != Some(symbolic_labelled_transition_system_mark().copy()) {
+    if ATermRead::read_aterm(&mut stream)?.map(|t| t.copy()) != Some(symbolic_labelled_transition_system_mark().copy())
+    {
         return Err("Expected symbolic labelled transition system stream".into());
     }
 
     let data_spec = DataSpecification::read(&mut stream)?;
-    let process_parameters: ATermList<DataVariable> = stream.read_aterm()?.ok_or("Expected process parameters")?.protect().into();
+    let process_parameters: ATermList<DataVariable> = stream
+        .read_aterm()?
+        .ok_or("Expected process parameters")?
+        .protect()
+        .into();
     let process_parameters: Vec<DataVariable> = process_parameters.to_vec();
 
     let initial_state = stream.read_ldd(storage)?;

--- a/crates/symbolic/src/io_symbolic_lts.rs
+++ b/crates/symbolic/src/io_symbolic_lts.rs
@@ -61,8 +61,7 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
     let aterm_stream = BinaryATermReader::new(BufReader::new(reader))?;
     let mut stream = BinaryLddReader::new(storage, aterm_stream)?;
 
-    if ATermRead::read_aterm(&mut stream)?.map(|t| t.protect()) != Some(symbolic_labelled_transition_system_mark())
-    {
+    if ATermRead::read_aterm(&mut stream)?.map(|t| t.protect()) != Some(symbolic_labelled_transition_system_mark()) {
         return Err("Expected symbolic labelled transition system stream".into());
     }
 

--- a/crates/symbolic/src/io_symbolic_lts.rs
+++ b/crates/symbolic/src/io_symbolic_lts.rs
@@ -61,7 +61,7 @@ pub fn read_symbolic_lts<R: Read>(storage: &mut Storage, reader: R) -> Result<Sy
     let aterm_stream = BinaryATermReader::new(BufReader::new(reader))?;
     let mut stream = BinaryLddReader::new(storage, aterm_stream)?;
 
-    if ATermRead::read_aterm(&mut stream)?.map(|t| t.copy()) != Some(symbolic_labelled_transition_system_mark().copy())
+    if ATermRead::read_aterm(&mut stream)?.map(|t| t.protect()) != Some(symbolic_labelled_transition_system_mark())
     {
         return Err("Expected symbolic labelled transition system stream".into());
     }


### PR DESCRIPTION
This pull request should speed up the reading of `.lts`, although this should be measured. In any case we also implement the unprotected terms for writing `.lts` files which helps regardless. In this pull request we should also check whether garbage collection is triggered at the right times.